### PR TITLE
Handle attachmentLayout (carousel/list) into conversation

### DIFF
--- a/packages/botkit/src/conversation.ts
+++ b/packages/botkit/src/conversation.ts
@@ -803,7 +803,9 @@ export class BotkitConversation<O extends object = {}> extends Dialog<O> {
         }
 
         outgoing.channelData = outgoing.channelData ? outgoing.channelData : {};
-
+        if (line.attachmentLayout) {
+                outgoing.attachmentLayout = line.attachmentLayout;
+        }
         /*******************************************************************************************************************/
         // allow dynamic generation of quick replies and/or attachments
         if (typeof(line.quick_replies)=='function') {


### PR DESCRIPTION
Enable carousel layout view in emulator or supported channel by processing of parent level parameter builder.AttachmentLayout.carousel or builder.AttachmentLayout.list into makeOutgoing

Sample :

{
  "attachmentLayout": "carousel",
  "attachments": [
    {
      "content": {
        "buttons": [
          {
            "title": "Button",
            "type": "postBack",
            "value": "payloadwxcvb"
          }, ...

Change has no harm at all